### PR TITLE
chore: JSX Props 자동 정렬 규칙 추가

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,17 @@
 {
   "tailwindCSS.experimental.configFile": "apps/monitor-web/tailwind.config.js",
-  "cSpell.words": ["jikwon"]
+  "cSpell.words": ["jikwon", "supabase"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.workingDirectories": [
+    { "directory": "apps/monitor-web", "changeProcessCWD": true }
+  ],
+
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ]
 }

--- a/apps/monitor-web/.eslintrc.json
+++ b/apps/monitor-web/.eslintrc.json
@@ -13,7 +13,38 @@
       "files": ["*.ts", "*.tsx"],
       "parser": "@typescript-eslint/parser",
       "extends": ["plugin:@typescript-eslint/recommended"],
-      "plugins": ["@typescript-eslint"]
+      "plugins": ["@typescript-eslint", "perfectionist"],
+      "rules": {
+        "perfectionist/sort-jsx-props": [
+          "warn",
+          {
+            "type": "alphabetical",
+            "groups": ["reserved", "id", "accessibility", "styling", "unknown", "callback"],
+            "customGroups": [
+              {
+                "groupName": "reserved",
+                "elementNamePattern": "^(key|ref)$"
+              },
+              {
+                "groupName": "id",
+                "elementNamePattern": "^id$"
+              },
+              {
+                "groupName": "styling",
+                "elementNamePattern": "^(className|style)$"
+              },
+              {
+                "groupName": "accessibility",
+                "elementNamePattern": "^(aria-.*|role|tabIndex|alt)$"
+              },
+              {
+                "groupName": "callback",
+                "elementNamePattern": "^on[A-Z].*"
+              }
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/apps/monitor-web/package.json
+++ b/apps/monitor-web/package.json
@@ -29,6 +29,8 @@
     "@typescript-eslint/eslint-plugin": "^6.16.0",
     "@typescript-eslint/parser": "^6.16.0",
     "@vitejs/plugin-react": "^4.2.0",
+    "eslint": "^8.57.1",
+    "eslint-plugin-perfectionist": "^5.9.0",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "0.0.0-insiders.f7d2598",

--- a/apps/monitor-web/src/App.tsx
+++ b/apps/monitor-web/src/App.tsx
@@ -9,13 +9,13 @@ export default function App() {
 
       <main className="flex-1 overflow-y-auto p-8">
         <Routes>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/errors" element={<ErrorLog />} />
-          <Route path="/api/:apiId" element={<ApiDetail />} />
-          <Route path="/api/:apiId/edit" element={<ApiEdit />} />
-          <Route path="/api/:apiId/errors/:errorId" element={<ErrorDetail />} />
-          <Route path="*" element={<NotFound />} />
+          <Route element={<Dashboard />} path="/" />
+          <Route element={<Login />} path="/login" />
+          <Route element={<ErrorLog />} path="/errors" />
+          <Route element={<ApiDetail />} path="/api/:apiId" />
+          <Route element={<ApiEdit />} path="/api/:apiId/edit" />
+          <Route element={<ErrorDetail />} path="/api/:apiId/errors/:errorId" />
+          <Route element={<NotFound />} path="*" />
         </Routes>
       </main>
     </div>

--- a/apps/monitor-web/src/components/common/Nav.tsx
+++ b/apps/monitor-web/src/components/common/Nav.tsx
@@ -20,7 +20,6 @@ const Nav = () => {
         {navItems.map(({ label, to }) => (
           <NavLink
             key={to}
-            aria-label={"asd"}
             className={({ isActive }) =>
               `rounded-md px-3 py-2 text-sm font-medium transition-colors ${
                 isActive ? "bg-gray-900 text-white" : "text-gray-600 hover:bg-gray-100"

--- a/apps/monitor-web/src/components/common/Nav.tsx
+++ b/apps/monitor-web/src/components/common/Nav.tsx
@@ -20,13 +20,14 @@ const Nav = () => {
         {navItems.map(({ label, to }) => (
           <NavLink
             key={to}
-            to={to}
-            end
+            aria-label={"asd"}
             className={({ isActive }) =>
               `rounded-md px-3 py-2 text-sm font-medium transition-colors ${
                 isActive ? "bg-gray-900 text-white" : "text-gray-600 hover:bg-gray-100"
               }`
             }
+            end
+            to={to}
           >
             {label}
           </NavLink>


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- issue #4
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- JSX Props가 저장 시 기존에 정의해둔 우선순위에 맞게 자동 정렬되도록 설정했습니다.
- 정렬이 필요한 부분은 경고 표시가 발생합니다.
- `eslint-plugin-perfectionist`를 사용했습니다.

## JSX Props 자동 정렬 기준

가독성과 접근성을 고려하여 아래 우선순위로 Props가 자동 정렬됩니다.

1. **예약어** (`key`, `ref`)
2. **식별자** (`id`)
3. **접근성** (`aria-*`, `role`, `tabIndex`, `alt`)
4. **스타일** (`className`, `style`)
5. **일반 Props** (나머지 속성, 알파벳 순 정렬)
6. **콜백/이벤트** (`onClick`, `onChange` 등)

## 참고 사항

- 로컬 환경에서 정상적으로 동작하는지 테스트 후 말씀 부탁드립니다.
- 자동 정렬 기준 변경이 필요한 부분이 있다면 코멘트 부탁드립니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거