### PR TITLE
chore: develop-to-main-pr.yml 본문 업데이트 누락 수정

### DIFF
--- a/.github/workflows/develop-to-main-pr.yml
+++ b/.github/workflows/develop-to-main-pr.yml
@@ -18,26 +18,39 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get Changelog
-        id: changelog
+      - name: Create or Update Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.YML_GITHUB_TOKEN }}
         run: |
           git fetch origin main
-          LOGS=$(git log origin/main..HEAD --merges --pretty=format:"%s" | grep "^Merge pull request" | sed 's/^/- /')
-          echo "logs<<EOF" >> $GITHUB_OUTPUT
-          echo "$LOGS" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          
+          LOGS=$(git log origin/main..HEAD --merges --pretty=format:"%s" | grep "^Merge pull request" | sed 's/^/- /' || true)
+          
+          cat << 'EOF' > /tmp/pr_body.md
+          ## 작업 요약
+          Develop 브랜치의 최신 변경 사항을 Main 브랜치로 반영합니다.
 
-      - name: Create or Update Pull Request
-        uses: repo-sync/pull-request@v2
-        with:
-          source_branch: "develop"
-          destination_branch: "main"
-          pr_title: "[배포 대기] main 최신화"
-          pr_body: |
-            ## 작업 요약
-            Develop 브랜치의 최신 변경 사항을 Main 브랜치로 반영합니다.
+          ### 최근 머지된 내역
+          EOF
+          
+          if [ -n "$LOGS" ]; then
+            printf '%s\n' "$LOGS" >> /tmp/pr_body.md
+          else
+            echo "새로 추가된 머지 내역이 없습니다." >> /tmp/pr_body.md
+          fi
 
-            ### 최근 머지된 내역
-            ${{ steps.changelog.outputs.logs }}
-          pr_label: "main"
-          github_token: ${{ secrets.YML_GITHUB_TOKEN }}
+          PR_NUMBER=$(gh pr list --base main --head develop --state open --json number -q '.[0].number')
+          
+          if [ -z "$PR_NUMBER" ]; then
+            gh pr create \
+              --base main \
+              --head develop \
+              --title "[배포 대기] main 최신화" \
+              --body-file /tmp/pr_body.md \
+              --label "main"
+          else
+            gh pr edit $PR_NUMBER \
+              --title "[배포 대기] main 최신화" \
+              --body-file /tmp/pr_body.md \
+              --add-label "main"
+          fi


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- issue #4
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `develop -> main` 자동 PR의 본문이 최신 변경사항으로 업데이트되지 않는 문제를 수정했습니다.
- 기존 PR이 이미 열려 있는 경우, GitHub CLI를 사용해 PR 본문을 덮어쓰도록 변경했습니다.

## 참고 사항

- 기존 `repo-sync/pull-request` 액션 대신 `gh pr create`, `gh pr edit` 명령어를 사용하도록 변경했습니다.
- PR 본문은 `/tmp/pr_body.md` 파일로 생성한 뒤 `--body-file` 옵션으로 전달합니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거