### PR TITLE
feat: 상태 UI 공통 컴포넌트 추가

### DIFF
--- a/apps/monitor-web/src/components/index.ts
+++ b/apps/monitor-web/src/components/index.ts
@@ -1,1 +1,2 @@
 export * from "./common";
+export * from "./status";

--- a/apps/monitor-web/src/components/status/EmptyState.tsx
+++ b/apps/monitor-web/src/components/status/EmptyState.tsx
@@ -27,7 +27,7 @@ interface EmptyStateProps {
  * // 기본
  * <EmptyState />
  *
- * // 아이콘·메시지 커스텀
+ * // 아이콘, 메시지 커스텀
  * <EmptyState icon="check" iconClassName="text-blue-400" message="검색 결과가 없습니다." />
  */
 

--- a/apps/monitor-web/src/components/status/EmptyState.tsx
+++ b/apps/monitor-web/src/components/status/EmptyState.tsx
@@ -1,8 +1,47 @@
-const EmptyState = () => {
+import { Icon, type IconName } from "@/components/common";
+import { StatusLayout } from "./_internal";
+
+/**
+ * 데이터 조회 결과가 없는 빈 상태 UI입니다.
+ *
+ * @remarks
+ * - `message`를 생략하면 기본 문구 "데이터가 없습니다."를 표시합니다.
+ * - `icon`을 생략하면 아이콘 없이 메시지만 표시됩니다.
+ *
+ * @author jikwon
+ */
+
+interface EmptyStateProps {
+  /** 빈 상태 안내 메시지 */
+  message?: string;
+  /** 표시할 아이콘 */
+  icon?: IconName;
+  /** 아이콘 크기 (default: `32`) */
+  iconSize?: number;
+  /** 아이콘에 적용할 스타일 (default: `"text-gray-400"`) */
+  iconClassName?: string;
+}
+
+/**
+ * @example
+ * // 기본
+ * <EmptyState />
+ *
+ * // 아이콘·메시지 커스텀
+ * <EmptyState icon="check" iconClassName="text-blue-400" message="검색 결과가 없습니다." />
+ */
+
+const EmptyState = ({
+  message = "데이터가 없습니다.",
+  icon,
+  iconSize = 32,
+  iconClassName = "text-gray-400",
+}: EmptyStateProps) => {
   return (
-    <div>
-      <h1>에러 컴포넌트</h1>
-    </div>
+    <StatusLayout>
+      {icon && <Icon className={iconClassName} name={icon} size={iconSize} />}
+      <p className="text-sm text-gray-500">{message}</p>
+    </StatusLayout>
   );
 };
 

--- a/apps/monitor-web/src/components/status/EmptyState.tsx
+++ b/apps/monitor-web/src/components/status/EmptyState.tsx
@@ -1,0 +1,9 @@
+const EmptyState = () => {
+  return (
+    <div>
+      <h1>에러 컴포넌트</h1>
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/apps/monitor-web/src/components/status/ErrorState.tsx
+++ b/apps/monitor-web/src/components/status/ErrorState.tsx
@@ -1,8 +1,52 @@
-const ErrorState = () => {
+import { ReactNode } from "react";
+import { Icon, type IconName } from "@/components/common";
+import { StatusLayout } from "./_internal";
+
+/**
+ * 데이터 로딩 실패 등 오류 상태 UI입니다.
+ *
+ * @remarks
+ * - `message`를 생략하면 기본 문구 "오류가 발생했습니다."를 표시합니다.
+ * - `icon`을 생략하면 아이콘 없이 메시지만 표시됩니다.
+ *
+ * @author jikwon
+ */
+
+interface ErrorStateProps {
+  /** 오류 안내 메시지 */
+  message?: string;
+  /** 표시할 아이콘 */
+  icon?: IconName;
+  /** 아이콘 크기 (default: `32`) */
+  iconSize?: number;
+  /** 아이콘에 적용할 스타일 (default: `"text-gray-400"`) */
+  iconClassName?: string;
+  /** 추가 UI */
+  children?: ReactNode;
+}
+
+/**
+ * @example
+ * // 기본
+ * <ErrorState />
+ *
+ * // 커스텀 아이콘·메시지
+ * <ErrorState icon="clear" message="데이터를 불러오는 중 문제가 발생했습니다." />
+ */
+
+const ErrorState = ({
+  message = "오류가 발생했습니다.",
+  icon,
+  iconSize = 32,
+  iconClassName = "text-gray-400",
+  children,
+}: ErrorStateProps) => {
   return (
-    <div>
-      <h1>에러 컴포넌트</h1>
-    </div>
+    <StatusLayout role="alert">
+      {icon && <Icon className={iconClassName} name={icon} size={iconSize} />}
+      <p className="text-sm text-gray-500">{message}</p>
+      {children}
+    </StatusLayout>
   );
 };
 

--- a/apps/monitor-web/src/components/status/ErrorState.tsx
+++ b/apps/monitor-web/src/components/status/ErrorState.tsx
@@ -30,7 +30,7 @@ interface ErrorStateProps {
  * // 기본
  * <ErrorState />
  *
- * // 커스텀 아이콘·메시지
+ * // 아이콘, 메시지 커스텀
  * <ErrorState icon="clear" message="데이터를 불러오는 중 문제가 발생했습니다." />
  */
 

--- a/apps/monitor-web/src/components/status/ErrorState.tsx
+++ b/apps/monitor-web/src/components/status/ErrorState.tsx
@@ -1,0 +1,9 @@
+const ErrorState = () => {
+  return (
+    <div>
+      <h1>에러 컴포넌트</h1>
+    </div>
+  );
+};
+
+export default ErrorState;

--- a/apps/monitor-web/src/components/status/LoadingState.tsx
+++ b/apps/monitor-web/src/components/status/LoadingState.tsx
@@ -1,0 +1,9 @@
+const LoadingState = () => {
+  return (
+    <div>
+      <h1>로딩 컴포넌트</h1>
+    </div>
+  );
+};
+
+export default LoadingState;

--- a/apps/monitor-web/src/components/status/LoadingState.tsx
+++ b/apps/monitor-web/src/components/status/LoadingState.tsx
@@ -1,8 +1,36 @@
-const LoadingState = () => {
+import { LoadingSpinner } from "@/components/common";
+import { StatusLayout } from "./_internal";
+
+/**
+ * 데이터 로딩 중 상태 UI입니다.
+ *
+ * @remarks
+ * - `LoadingSpinner`의 `role="status"`가 스크린 리더 접근성을 처리합니다.
+ * - `message`를 생략하면 스피너만 표시됩니다.
+ *
+ * @author jikwon
+ */
+
+interface LoadingStateProps {
+  /** 로딩 스피너 아래 표시할 안내 메시지 */
+  message?: string;
+}
+
+/**
+ * @example
+ * // 기본
+ * <LoadingState />
+ *
+ * // 메시지 포함
+ * <LoadingState message="데이터를 불러오는 중입니다." />
+ */
+
+const LoadingState = ({ message }: LoadingStateProps) => {
   return (
-    <div>
-      <h1>로딩 컴포넌트</h1>
-    </div>
+    <StatusLayout>
+      <LoadingSpinner size={32} />
+      {message && <p className="text-sm text-gray-500">{message}</p>}
+    </StatusLayout>
   );
 };
 

--- a/apps/monitor-web/src/components/status/LoadingState.tsx
+++ b/apps/monitor-web/src/components/status/LoadingState.tsx
@@ -27,7 +27,7 @@ interface LoadingStateProps {
 
 const LoadingState = ({ message }: LoadingStateProps) => {
   return (
-    <StatusLayout>
+    <StatusLayout role="none">
       <LoadingSpinner size={32} />
       {message && <p className="text-sm text-gray-500">{message}</p>}
     </StatusLayout>

--- a/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
+++ b/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
@@ -1,0 +1,9 @@
+const StatusLayout = () => {
+  return (
+    <div>
+      <h1>상태 레이아웃 컴포넌트</h1>
+    </div>
+  );
+};
+
+export default StatusLayout;

--- a/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
+++ b/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/utils";
 interface StatusLayoutProps {
   /** error, empty, loading 상태 UI 요소 */
   children: ReactNode;
-  /** 기본 `py-20 gap-5` 스타일을 오버라이드할 Tailwind 클래스 */
+  /** 기본 `py-20 gap-5` 스타일을 오버라이드할 스타일 */
   className?: string;
   /** 스크린 리더 알림 방식. error는 "alert", 그 외는 "status" */
   role?: "status" | "alert";

--- a/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
+++ b/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
@@ -16,8 +16,8 @@ interface StatusLayoutProps {
   children: ReactNode;
   /** 기본 `py-20 gap-5` 스타일을 오버라이드할 스타일 */
   className?: string;
-  /** 스크린 리더 알림 방식. error는 "alert", 그 외는 "status" */
-  role?: "status" | "alert";
+  /** 스크린 리더 알림 방식. error는 "alert", 자식이 role을 직접 처리할 때는 "none", 그 외는 "status" */
+  role?: "status" | "alert" | "none";
 }
 
 /**

--- a/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
+++ b/apps/monitor-web/src/components/status/_internal/StatusLayout.tsx
@@ -1,7 +1,46 @@
-const StatusLayout = () => {
+import { ReactNode } from "react";
+import { cn } from "@/utils";
+
+/**
+ * 공통 상태 컴포넌트(error, empty, loading)의 레이아웃 래퍼입니다.
+ *
+ * @remarks
+ * - error, empty, loading 등 상태 컴포넌트의 공통 레이아웃 래퍼입니다.
+ * - `className`으로 기본 `py-20 gap-5` 스타일을 오버라이드할 수 있습니다.
+ *
+ * @author jikwon
+ */
+
+interface StatusLayoutProps {
+  /** error, empty, loading 상태 UI 요소 */
+  children: ReactNode;
+  /** 기본 `py-20 gap-5` 스타일을 오버라이드할 Tailwind 클래스 */
+  className?: string;
+  /** 스크린 리더 알림 방식. error는 "alert", 그 외는 "status" */
+  role?: "status" | "alert";
+}
+
+/**
+ * @example
+ * ```tsx
+ * <StatusLayout>
+ *   <EmptyIcon />
+ *   <p>데이터가 없습니다.</p>
+ * </StatusLayout>
+ * ```
+ *
+ * ```tsx
+ * <StatusLayout role="alert">
+ *   <ErrorIcon />
+ *   <p>데이터를 불러오는 중 오류가 발생했습니다.</p>
+ * </StatusLayout>
+ * ```
+ */
+
+const StatusLayout = ({ children, className, role = "status" }: StatusLayoutProps) => {
   return (
-    <div>
-      <h1>상태 레이아웃 컴포넌트</h1>
+    <div role={role} className={cn("h-full w-full gap-5 py-20 flex-col-center", className)}>
+      {children}
     </div>
   );
 };

--- a/apps/monitor-web/src/components/status/_internal/index.ts
+++ b/apps/monitor-web/src/components/status/_internal/index.ts
@@ -1,0 +1,1 @@
+export { default as StatusLayout } from "./StatusLayout";

--- a/apps/monitor-web/src/components/status/index.ts
+++ b/apps/monitor-web/src/components/status/index.ts
@@ -1,0 +1,3 @@
+export { default as EmptyState } from "./EmptyState";
+export { default as ErrorState } from "./ErrorState";
+export { default as LoadingState } from "./LoadingState";


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- issue #4
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `StatusLayout.tsx`
  - 상태 UI에서 공통으로 사용하는 레이아웃 컴포넌트입니다.
  - `role` prop을 전달할 수 있으며, 기본값은 `"status"`입니다.

- `ErrorState.tsx`
  - 에러 상태를 표시하는 컴포넌트입니다.
  - `role="alert"`를 사용합니다.
  - `message` prop으로 안내 문구를 설정할 수 있습니다.
  - `children`으로 추가 UI를 렌더링할 수 있습니다.

- `EmptyState.tsx`
  - 빈 상태를 표시하는 컴포넌트입니다.
  - `message` prop으로 안내 문구를 설정할 수 있습니다.

- `LoadingState.tsx`
  - 로딩 상태를 표시하는 컴포넌트입니다.
  - 로딩 스피너를 렌더링하며, 선택적으로 `message`를 추가할 수 있습니다.

## 참고 사항

- 현재 `ErrorState.tsx`와 `EmptyState.tsx`는 동일한 디자인을 사용하고 있습니다.
- 디자인 시안이 확정되면 각 상태별 스타일을 업데이트하겠습니다.
- 아이콘 관련 prop을 객체로 묶는 방식도 고민해봤지만, 현재는 사용하는 쪽의 가독성과 코드 길이를 고려해 개별 prop으로 분리했습니다.
- 추후 아이콘 관련 prop이 많아진다면 객체 형태로 묶는 방식으로 변경하겠습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거