### PR TITLE
feat : Badge Component 구현

### DIFF
--- a/apps/monitor-web/src/components/common/display/Badge.tsx
+++ b/apps/monitor-web/src/components/common/display/Badge.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/utils";
+
+type ApiStatus = "healthy" | "degraded" | "outage";
+
+type StatusBadgeProps = {
+  status: ApiStatus;
+  label?: never;
+  className?: string;
+};
+
+type CustomBadgeProps = {
+  label: string;
+  status?: never;
+  className?: string;
+};
+
+type BadgeProps = StatusBadgeProps | CustomBadgeProps;
+
+const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; className: string }> = {
+  healthy: {
+    label: "정상",
+    className: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  },
+  degraded: {
+    label: "지연",
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+  },
+  outage: {
+    label: "장애",
+    className: "bg-rose-50 text-rose-700 border-rose-200",
+  },
+};
+
+const BADGE_BASE_STYLE =
+  "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-[100px] border px-3 py-1 text-xs font-medium";
+
+const Badge = (props: BadgeProps) => {
+  if (props.status !== undefined) {
+    const meta = API_STATUS_BADGE_STYLES[props.status];
+    return (
+      <span className={cn(BADGE_BASE_STYLE, meta.className, props.className)}>{meta.label}</span>
+    );
+  }
+
+  return <span className={cn(BADGE_BASE_STYLE, props.className)}>{props.label}</span>;
+};
+
+export default Badge;

--- a/apps/monitor-web/src/components/common/display/Badge.tsx
+++ b/apps/monitor-web/src/components/common/display/Badge.tsx
@@ -1,6 +1,9 @@
 import { cn } from "@/utils";
-
-type ApiStatus = "healthy" | "degraded" | "outage";
+import {
+  API_STATUS_BADGE_STYLES,
+  BADGE_BASE_STYLE,
+  type ApiStatus,
+} from "./_internal/badge.constants";
 
 type StatusBadgeProps = {
   status: ApiStatus;
@@ -15,24 +18,6 @@ type CustomBadgeProps = {
 };
 
 type BadgeProps = StatusBadgeProps | CustomBadgeProps;
-
-const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; className: string }> = {
-  healthy: {
-    label: "정상",
-    className: "bg-emerald-50 text-emerald-700 border-emerald-200",
-  },
-  degraded: {
-    label: "지연",
-    className: "bg-amber-50 text-amber-700 border-amber-200",
-  },
-  outage: {
-    label: "장애",
-    className: "bg-rose-50 text-rose-700 border-rose-200",
-  },
-};
-
-const BADGE_BASE_STYLE =
-  "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-[100px] border px-3 py-1 text-xs font-medium";
 
 const Badge = (props: BadgeProps) => {
   if (props.status !== undefined) {

--- a/apps/monitor-web/src/components/common/display/Badge.tsx
+++ b/apps/monitor-web/src/components/common/display/Badge.tsx
@@ -5,25 +5,57 @@ import {
   type ApiStatus,
 } from "./_internal/badge.constants";
 
+/**
+ * 공통 Badge 컴포넌트입니다.
+ *
+ * @remarks
+ * - API Status Badge와 Custom Badge를 모두 지원합니다.
+ * - `status`를 전달하면 사전 정의된 라벨과 스타일이 적용됩니다.
+ * - `label`을 전달하면 커스텀 텍스트 배지로 렌더링됩니다.
+ *
+ * @author junyeol
+ */
+
 type StatusBadgeProps = {
+  /** API 상태값 */
   status: ApiStatus;
+  /** Status Badge에서는 직접 label 지정 불가 */
   label?: never;
+  /** 추가 클래스명 */
   className?: string;
 };
 
 type CustomBadgeProps = {
+  /** Custom Badge Label */
   label: string;
+  /** Custom Badge에서는 status 지정 불가 */
   status?: never;
+  /** 추가 클래스명 */
   className?: string;
 };
 
 type BadgeProps = StatusBadgeProps | CustomBadgeProps;
 
+/**
+ * @example
+ * ```tsx
+ * // Status Badge 예시
+ * <Badge status="healthy" />
+ * <Badge status="degraded" />
+ * <Badge status="outage" />
+ *
+ * // Custom Badge 예시
+ * <Badge label="커스텀 배지" className="bg-blue-50 text-blue-700 border-blue-200" />
+ * ```
+ */
+
 const Badge = (props: BadgeProps) => {
   if (props.status !== undefined) {
-    const meta = API_STATUS_BADGE_STYLES[props.status];
+    const statusBadge = API_STATUS_BADGE_STYLES[props.status];
     return (
-      <span className={cn(BADGE_BASE_STYLE, meta.className, props.className)}>{meta.label}</span>
+      <span className={cn(BADGE_BASE_STYLE, statusBadge.className, props.className)}>
+        {statusBadge.label}
+      </span>
     );
   }
 

--- a/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
+++ b/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
@@ -48,4 +48,4 @@ export const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; classNa
  */
 
 export const BADGE_BASE_STYLE =
-  "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-[100px] border px-3 py-1 text-xs font-medium";
+  "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-full border px-3 py-1 text-xs font-medium";

--- a/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
+++ b/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
@@ -1,0 +1,19 @@
+export type ApiStatus = "healthy" | "degraded" | "outage";
+
+export const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; className: string }> = {
+  healthy: {
+    label: "정상",
+    className: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  },
+  degraded: {
+    label: "지연",
+    className: "bg-amber-50 text-amber-700 border-amber-200",
+  },
+  outage: {
+    label: "장애",
+    className: "bg-rose-50 text-rose-700 border-rose-200",
+  },
+};
+
+export const BADGE_BASE_STYLE =
+  "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-[100px] border px-3 py-1 text-xs font-medium";

--- a/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
+++ b/apps/monitor-web/src/components/common/display/_internal/badge.constants.ts
@@ -1,4 +1,27 @@
+// TODO(준열) : 디자인 시스템 정립에 따라 기본 스타일 및 API 상태에 따른 스타일 변경 예정
+
+/**
+ * Badge 컴포넌트에서 사용하는 API 상태 타입입니다.
+ *
+ * @remarks
+ * - `healthy`: 정상
+ * - `degraded`: 지연
+ * - `outage`: 장애
+ *
+ * @author junyeol
+ */
+
 export type ApiStatus = "healthy" | "degraded" | "outage";
+
+/**
+ * API 상태별 Badge 표시 정보입니다.
+ *
+ * @remarks
+ * - `label`: 상태별 노출 텍스트
+ * - `className`: 상태별 색상 및 테두리 스타일
+ *
+ * @author junyeol
+ */
 
 export const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; className: string }> = {
   healthy: {
@@ -14,6 +37,15 @@ export const API_STATUS_BADGE_STYLES: Record<ApiStatus, { label: string; classNa
     className: "bg-rose-50 text-rose-700 border-rose-200",
   },
 };
+
+/**
+ * Badge 공통 베이스 스타일입니다.
+ *
+ * @remarks
+ * - 레이아웃, 크기, 타이포그래피, 기본 테두리를 정의합니다.
+ *
+ * @author junyeol
+ */
 
 export const BADGE_BASE_STYLE =
   "inline-flex w-fit h-6 items-center justify-center gap-1 rounded-[100px] border px-3 py-1 text-xs font-medium";

--- a/apps/monitor-web/src/components/common/display/index.ts
+++ b/apps/monitor-web/src/components/common/display/index.ts
@@ -2,3 +2,4 @@ export { default as Icon } from "./Icon";
 export type { IconName } from "./Icon";
 export { default as Image } from "./Image";
 export { default as Avatar } from "./Avatar";
+export { default as Badge } from "./Badge";

--- a/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
@@ -9,6 +9,7 @@ import {
   BasicButton,
   IconButton,
   ModalLayout,
+  Badge,
 } from "@/components";
 import { useToast } from "@/hooks";
 import { useMockListQuery } from "@/queries";
@@ -140,6 +141,13 @@ const Dashboard = () => {
           <BasicButton onClick={() => setOpen(false)}>닫기</BasicButton>
         </div>
       </ModalLayout>
+
+      <div className="flex flex-col gap-4">
+        <Badge status="healthy" />
+        <Badge status="degraded" />
+        <Badge status="outage" />
+        <Badge className="border-blue-200 bg-blue-50 text-blue-700" label="커스텀 배지" />
+      </div>
     </div>
   );
 };

--- a/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
@@ -142,7 +142,7 @@ const Dashboard = () => {
         </div>
       </ModalLayout>
 
-      <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 pt-5">
         <Badge status="healthy" />
         <Badge status="degraded" />
         <Badge status="outage" />


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- issue #9 
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `Badge.tsx`
   
    - API Status Badge 와 Custom Badge 두 가지 형태로 사용할 수 있는 컴포넌트를 구현하였습니다.
    
- `display/_internal/badge.constants.ts`

    - Status Badge에 사용될 스타일링 속성과 공통으로 사용될 스타일링 속성을 분리하여 관리할 수 있도록 구현하였습니다.
   
## 참고 사항

- 공통 스타일링 속성은 운영팀 Badge Component를 참고해서 작성하였습니다.

- API 상태에 대한 표시 UI로 판단하고 작업하였습니다.

- 스타일링 속성들을 선언한 상수들을 편하게 관리하기 위해 내부폴더를 만들어서 위치해두었는데, 괜찮을지 확인 부탁드립니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거
