### PR TITLE
feat: 로그인 기능 추가

### DIFF
--- a/apps/monitor-web/src/components/common/buttons/_internal/buttons.constants.ts
+++ b/apps/monitor-web/src/components/common/buttons/_internal/buttons.constants.ts
@@ -33,4 +33,4 @@ export const VARIANT_STYLES = {
 } as const;
 
 export const BASE_STYLES =
-  "inline-flex min-w-20 items-center justify-center gap-2 rounded-lg transition-colors duration-150 disabled:cursor-not-allowed";
+  "relative inline-flex min-w-20 items-center justify-center gap-2 rounded-lg transition-colors duration-150 disabled:cursor-not-allowed";

--- a/apps/monitor-web/src/components/common/feedback/Toast.tsx
+++ b/apps/monitor-web/src/components/common/feedback/Toast.tsx
@@ -61,21 +61,28 @@ const Toast = ({ toast }: ToastProps) => {
       aria-atomic="true"
       role={ROLE_MAP[toast.type]}
       className={cn(
-        "animate-toast-in flex min-w-64 max-w-sm items-center gap-3 rounded-lg px-4 py-3 shadow-lg",
+        "animate-toast-in flex min-w-64 max-w-sm items-center gap-3 rounded-lg p-5 shadow-lg",
         STYLE_MAP[toast.type]
       )}
     >
       <span aria-hidden className="text-base font-bold">
         {ICON_MAP[toast.type]}
       </span>
-      <p className="flex-1 text-sm">{toast.message}</p>
-      <button
-        aria-label="닫기"
-        className="ml-1 text-sm opacity-60 transition-opacity hover:opacity-100"
-        onClick={() => removeToast(toast.id)}
-      >
-        <span aria-hidden>X</span>
-      </button>
+
+      <div className="flex flex-1 items-start justify-between">
+        <div className="flex flex-col gap-[14px]">
+          <p className="flex-1 text-xl font-semibold leading-5">{toast.message}</p>
+          <span className="text-lg leading-4">{toast.description}</span>
+        </div>
+
+        <button
+          aria-label="닫기"
+          className="ml-1 text-sm opacity-60 transition-opacity hover:opacity-100"
+          onClick={() => removeToast(toast.id)}
+        >
+          <span aria-hidden>X</span>
+        </button>
+      </div>
     </div>
   );
 };

--- a/apps/monitor-web/src/components/common/feedback/Toast.tsx
+++ b/apps/monitor-web/src/components/common/feedback/Toast.tsx
@@ -26,7 +26,6 @@ const ICON_MAP: Record<ToastItem["type"], string> = {
   warning: "",
 };
 
-// error, warning은 즉시 읽어야 하므로 assertive, success는 polite
 const ROLE_MAP: Record<ToastItem["type"], "alert" | "status"> = {
   success: "status",
   error: "alert",
@@ -43,7 +42,7 @@ interface ToastProps {
  * ```tsx
  * // ToastContainer 내부에서 자동으로 렌더링됩니다.
  * // 직접 사용이 필요한 경우:
- * <Toast toast={{ id: "1", type: "success", message: "저장되었습니다." }} />
+ * <Toast toast={{ id: "1", type: "success", message: "저장되었습니다.", description: "변경 사항이 반영되었습니다." }} />
  * ```
  */
 

--- a/apps/monitor-web/src/hooks/useToast.ts
+++ b/apps/monitor-web/src/hooks/useToast.ts
@@ -71,8 +71,8 @@ export function useToastList() {
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
-function toast(message: string, type: ToastType, duration?: number) {
-  addToast({ message, type, duration });
+function toast(message: string, description: string, type: ToastType, duration?: number) {
+  addToast({ message, description, type, duration });
 }
 
 /**
@@ -104,9 +104,12 @@ function toast(message: string, type: ToastType, duration?: number) {
 export function useToast() {
   return useMemo(
     () => ({
-      success: (message: string, duration?: number) => toast(message, "success", duration),
-      error: (message: string, duration?: number) => toast(message, "error", duration),
-      warning: (message: string, duration?: number) => toast(message, "warning", duration),
+      success: (message: string, description: string, duration?: number) =>
+        toast(message, description, "success", duration),
+      error: (message: string, description: string, duration?: number) =>
+        toast(message, description, "error", duration),
+      warning: (message: string, description: string, duration?: number) =>
+        toast(message, description, "warning", duration),
     }),
     []
   );

--- a/apps/monitor-web/src/hooks/useToast.ts
+++ b/apps/monitor-web/src/hooks/useToast.ts
@@ -32,8 +32,8 @@ function getSnapshot() {
 /**
  * @example
  * ```ts
- * addToast({ type: "success", message: "저장되었습니다." });
- * addToast({ type: "error", message: "오류 발생", duration: 5000 });
+ * addToast({ type: "success", message: "저장되었습니다.", description: "변경 사항이 반영되었습니다." });
+ * addToast({ type: "error", message: "오류 발생", description: "잠시 후 다시 시도해 주세요.", duration: 5000 });
  * ```
  */
 
@@ -83,9 +83,9 @@ function toast(message: string, description: string, type: ToastType, duration?:
  * - 컴포넌트 외부에서 토스트를 발생시킬 때는 `addToast`를 직접 사용하세요.
  *
  * @returns 토스트 발생 메서드 객체
- * - `success`: 성공 토스트 표시
- * - `error`: 에러 토스트 표시
- * - `warning`: 경고 토스트 표시
+ * - `success(message, description, duration?)`: 성공 토스트 표시
+ * - `error(message, description, duration?)`: 에러 토스트 표시
+ * - `warning(message, description, duration?)`: 경고 토스트 표시
  *
  * @author jikwon
  */
@@ -95,9 +95,9 @@ function toast(message: string, description: string, type: ToastType, duration?:
  * ```tsx
  * const { success, error, warning } = useToast();
  *
- * success("저장되었습니다.");
- * error("요청에 실패했습니다.", 5000);
- * warning("주의가 필요한 작업입니다.");
+ * success("저장되었습니다.", "변경 사항이 반영되었습니다.");
+ * error("요청에 실패했습니다.", "잠시 후 다시 시도해 주세요.", 5000);
+ * warning("주의가 필요한 작업입니다.", "확인 후 진행해 주세요.");
  * ```
  */
 

--- a/apps/monitor-web/src/layouts/Nav.tsx
+++ b/apps/monitor-web/src/layouts/Nav.tsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 const PLACEHOLDER_API_ID = "1";
 const PLACEHOLDER_ERROR_ID = "1";
@@ -13,12 +13,6 @@ const navItems = [
 ];
 
 const Nav = () => {
-  const { pathname } = useLocation();
-
-  if (pathname === "/login") {
-    return null;
-  }
-
   return (
     <aside className="flex h-screen w-56 shrink-0 flex-col border-r bg-white px-3 py-6">
       <p className="mb-6 px-2 text-base font-bold text-gray-900">API 모니터링</p>

--- a/apps/monitor-web/src/lib/supabase.ts
+++ b/apps/monitor-web/src/lib/supabase.ts
@@ -6,7 +6,7 @@ const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 const cookieStorage = {
   getItem: (key: string): string | null => {
     const match = document.cookie.split("; ").find((row) => row.startsWith(`${key}=`));
-    return match ? decodeURIComponent(match.split("=")[1]) : null;
+    return match ? decodeURIComponent(match.slice(key.length + 1)) : null;
   },
   setItem: (key: string, value: string): void => {
     document.cookie = `${key}=${encodeURIComponent(value)}; path=/; SameSite=Lax; Secure`;

--- a/apps/monitor-web/src/lib/supabase.ts
+++ b/apps/monitor-web/src/lib/supabase.ts
@@ -3,4 +3,21 @@ import { createClient } from "@supabase/supabase-js";
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const cookieStorage = {
+  getItem: (key: string): string | null => {
+    const match = document.cookie.split("; ").find((row) => row.startsWith(`${key}=`));
+    return match ? decodeURIComponent(match.split("=")[1]) : null;
+  },
+  setItem: (key: string, value: string): void => {
+    document.cookie = `${key}=${encodeURIComponent(value)}; path=/; SameSite=Lax; Secure`;
+  },
+  removeItem: (key: string): void => {
+    document.cookie = `${key}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+  },
+};
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: cookieStorage,
+  },
+});

--- a/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import {
   ModalLayout,
 } from "@/components";
 import { useToast } from "@/hooks";
-import { useMockListQuery } from "@/queries";
+import { useLogoutMutation, useMockListQuery, useUserQuery } from "@/queries";
 
 const Dashboard = () => {
   const { data, isLoading } = useMockListQuery();
@@ -25,6 +25,8 @@ const Dashboard = () => {
   const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 
   const { success, error, warning } = useToast();
+  const { mutate: handleLogout } = useLogoutMutation();
+  const { data: user } = useUserQuery();
 
   if (isLoading) {
     return <div>로딩</div>;
@@ -32,6 +34,16 @@ const Dashboard = () => {
 
   return (
     <div className="flex flex-col gap-1">
+      <div className="my-2 border">
+        <p>현재 로그인된 유저 정보</p>
+        <p>{user ? user?.email : "로그인되지 않았습니다."}</p>
+        {!!user && (
+          <BasicButton className="mt-2" onClick={() => handleLogout()}>
+            로그아웃 버튼
+          </BasicButton>
+        )}
+      </div>
+
       <h1>대시보드</h1>
 
       <ul>

--- a/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
+++ b/apps/monitor-web/src/pages/Dashboard/Dashboard.tsx
@@ -45,19 +45,19 @@ const Dashboard = () => {
       <div className="mt-4 flex gap-2">
         <button
           className="rounded-lg bg-green-500 px-4 py-2 text-white transition-colors hover:bg-green-600"
-          onClick={() => success("성공 토스트")}
+          onClick={() => success("성공 토스트", "성공 토스트 입니다.")}
         >
           Success
         </button>
         <button
           className="rounded-lg bg-red-500 px-4 py-2 text-white transition-colors hover:bg-red-600"
-          onClick={() => error("실패 토스트")}
+          onClick={() => error("실패 토스트", "실패 토스트 입니다")}
         >
           Error
         </button>
         <button
           className="rounded-lg bg-yellow-500 px-4 py-2 text-black transition-colors hover:bg-yellow-600"
-          onClick={() => warning("경고 토스트")}
+          onClick={() => warning("경고 토스트", "경고 토스트 입니다")}
         >
           Warning
         </button>

--- a/apps/monitor-web/src/pages/Login/_components/LoginForm.tsx
+++ b/apps/monitor-web/src/pages/Login/_components/LoginForm.tsx
@@ -1,8 +1,11 @@
 import { BasicButton, TextField } from "@/components";
+import { useLoginForm } from "../hooks";
 
 const LoginForm = () => {
+  const { values, handleChange, handleSubmit, isDisabled, isPending } = useLoginForm();
+
   return (
-    <form className="flex w-full flex-col gap-[70px]">
+    <form className="flex w-full flex-col gap-[70px]" onSubmit={handleSubmit}>
       <fieldset className="flex flex-col gap-[30px]">
         <legend className="sr-only">로그인 정보</legend>
         <TextField
@@ -11,6 +14,8 @@ const LoginForm = () => {
           name="username"
           placeholder="관리자 계정 아이디를 입력해 주세요."
           type="text"
+          value={values.username}
+          onChange={handleChange("username")}
         />
         <TextField
           autoComplete="current-password"
@@ -18,10 +23,17 @@ const LoginForm = () => {
           name="password"
           placeholder="비밀번호를 입력해 주세요."
           type="password"
+          value={values.password}
+          onChange={handleChange("password")}
         />
       </fieldset>
 
-      <BasicButton className="min-h-[56px] text-[20px] font-bold leading-6" type="submit">
+      <BasicButton
+        className="min-h-[56px] text-[20px] font-bold leading-6"
+        disabled={isDisabled}
+        loading={isPending}
+        type="submit"
+      >
         로그인
       </BasicButton>
     </form>

--- a/apps/monitor-web/src/pages/Login/hooks/index.ts
+++ b/apps/monitor-web/src/pages/Login/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useLoginForm } from "./useLoginForm";

--- a/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
+++ b/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, useState } from "react";
 import { useLoginMutation } from "@/queries";
-import type { LoginFormValues } from "../types";
+import { LoginFormValues } from "../types";
 
 const useLoginForm = () => {
   const [values, setValues] = useState<LoginFormValues>({ username: "", password: "" });

--- a/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
+++ b/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
@@ -1,0 +1,24 @@
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useLoginMutation } from "@/queries";
+import type { LoginFormValues } from "../types";
+
+const useLoginForm = () => {
+  const [values, setValues] = useState<LoginFormValues>({ username: "", password: "" });
+  const { mutateAsync: login, isPending } = useLoginMutation();
+
+  const handleChange =
+    (field: "username" | "password") => (event: ChangeEvent<HTMLInputElement>) => {
+      setValues((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await login(values);
+  };
+
+  const isDisabled = isPending || !values.username.trim() || !values.password.trim();
+
+  return { values, handleChange, handleSubmit, isDisabled, isPending };
+};
+
+export default useLoginForm;

--- a/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
+++ b/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
@@ -13,6 +13,8 @@ const useLoginForm = () => {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (isPending) return;
+
     await login(values);
   };
 

--- a/apps/monitor-web/src/pages/Login/types/index.ts
+++ b/apps/monitor-web/src/pages/Login/types/index.ts
@@ -1,0 +1,4 @@
+export interface LoginFormValues {
+  username: string;
+  password: string;
+}

--- a/apps/monitor-web/src/pages/Login/types/index.ts
+++ b/apps/monitor-web/src/pages/Login/types/index.ts
@@ -1,4 +1,1 @@
-export interface LoginFormValues {
-  username: string;
-  password: string;
-}
+export * from "./loginFormValues";

--- a/apps/monitor-web/src/pages/Login/types/loginFormValues.ts
+++ b/apps/monitor-web/src/pages/Login/types/loginFormValues.ts
@@ -1,0 +1,4 @@
+export interface LoginFormValues {
+  username: string;
+  password: string;
+}

--- a/apps/monitor-web/src/queries/index.ts
+++ b/apps/monitor-web/src/queries/index.ts
@@ -1,1 +1,2 @@
 export * from "./mock";
+export * from "./login";

--- a/apps/monitor-web/src/queries/login/index.ts
+++ b/apps/monitor-web/src/queries/login/index.ts
@@ -1,0 +1,3 @@
+export { useLoginMutation } from "./login.queries";
+export { useLogoutMutation } from "./logout.queries";
+export { useUserQuery } from "./user.queries";

--- a/apps/monitor-web/src/queries/login/login.queries.ts
+++ b/apps/monitor-web/src/queries/login/login.queries.ts
@@ -1,0 +1,33 @@
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks";
+import useAppMutation from "../base/useAppMutation";
+import type { LoginFormValues } from "@/pages/Login/types";
+
+const loginWithEmail = async ({ username, password }: LoginFormValues) => {
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: username,
+    password,
+  });
+  if (error) throw error;
+  return data;
+};
+
+export const useLoginMutation = () => {
+  const navigate = useNavigate();
+  const { error: errorToast } = useToast();
+
+  return useAppMutation(loginWithEmail, {
+    onSuccess: () => {
+      navigate("/");
+    },
+
+    onError: (error: Error) => {
+      if (error.message === "Invalid login credentials") {
+        errorToast("로그인에 실패했습니다.", "아이디 또는 비밀번호가 올바르지 않습니다");
+        return;
+      }
+      errorToast("로그인에 실패했습니다.", "잠시 후 다시 시도해 주세요.");
+    },
+  });
+};

--- a/apps/monitor-web/src/queries/login/login.queries.ts
+++ b/apps/monitor-web/src/queries/login/login.queries.ts
@@ -2,7 +2,7 @@ import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks";
 import useAppMutation from "../base/useAppMutation";
-import type { LoginFormValues } from "@/pages/Login/types";
+import { LoginFormValues } from "@/pages/Login/types";
 
 const loginWithEmail = async ({ username, password }: LoginFormValues) => {
   const { data, error } = await supabase.auth.signInWithPassword({

--- a/apps/monitor-web/src/queries/login/login.queries.ts
+++ b/apps/monitor-web/src/queries/login/login.queries.ts
@@ -3,6 +3,8 @@ import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks";
 import useAppMutation from "../base/useAppMutation";
 import { LoginFormValues } from "@/pages/Login/types";
+import { useQueryClient } from "@tanstack/react-query";
+import { authQueryKeys } from "../queryKeys";
 
 const loginWithEmail = async ({ username, password }: LoginFormValues) => {
   const { data, error } = await supabase.auth.signInWithPassword({
@@ -15,15 +17,17 @@ const loginWithEmail = async ({ username, password }: LoginFormValues) => {
 
 export const useLoginMutation = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { error: errorToast } = useToast();
 
   return useAppMutation(loginWithEmail, {
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: authQueryKeys.user() });
       navigate("/");
     },
 
     onError: (error: Error) => {
-      if (error.message === "Invalid login credentials") {
+      if ("code" in error && error.code === "invalid_credentials") {
         errorToast("로그인에 실패했습니다.", "아이디 또는 비밀번호가 올바르지 않습니다");
         return;
       }

--- a/apps/monitor-web/src/queries/login/logout.queries.ts
+++ b/apps/monitor-web/src/queries/login/logout.queries.ts
@@ -2,6 +2,8 @@ import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks";
 import useAppMutation from "../base/useAppMutation";
+import { useQueryClient } from "@tanstack/react-query";
+import { authQueryKeys } from "../queryKeys";
 
 const logoutUser = async () => {
   const { error } = await supabase.auth.signOut();
@@ -10,10 +12,12 @@ const logoutUser = async () => {
 
 export const useLogoutMutation = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { error: errorToast } = useToast();
 
   return useAppMutation(logoutUser, {
     onSuccess: () => {
+      queryClient.removeQueries({ queryKey: authQueryKeys.all });
       navigate("/login");
     },
     onError: () => {

--- a/apps/monitor-web/src/queries/login/logout.queries.ts
+++ b/apps/monitor-web/src/queries/login/logout.queries.ts
@@ -1,0 +1,23 @@
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabase";
+import { useToast } from "@/hooks";
+import useAppMutation from "../base/useAppMutation";
+
+const logoutUser = async () => {
+  const { error } = await supabase.auth.signOut();
+  if (error) throw error;
+};
+
+export const useLogoutMutation = () => {
+  const navigate = useNavigate();
+  const { error: errorToast } = useToast();
+
+  return useAppMutation(logoutUser, {
+    onSuccess: () => {
+      navigate("/login");
+    },
+    onError: () => {
+      errorToast("로그아웃에 실패했습니다.", "잠시 후 다시 시도해 주세요.");
+    },
+  });
+};

--- a/apps/monitor-web/src/queries/login/user.queries.ts
+++ b/apps/monitor-web/src/queries/login/user.queries.ts
@@ -1,0 +1,16 @@
+import { supabase } from "@/lib/supabase";
+import useAppQuery from "../base/useAppQuery";
+import { authQueryKeys } from "../queryKeys";
+
+const getUser = async () => {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+  if (error) throw error;
+  return user;
+};
+
+export const useUserQuery = () => {
+  return useAppQuery(authQueryKeys.user(), getUser);
+};

--- a/apps/monitor-web/src/queries/queryKeys.ts
+++ b/apps/monitor-web/src/queries/queryKeys.ts
@@ -24,3 +24,8 @@ export const apisQueryKeys = {
   list: () => [...apisQueryKeys.all, "list"] as const,
   detail: (apiId: string) => [...apisQueryKeys.all, "detail", apiId] as const,
 };
+
+export const authQueryKeys = {
+  all: ["auth"] as const,
+  user: () => [...authQueryKeys.all, "user"] as const,
+};

--- a/apps/monitor-web/src/types/ToastType.ts
+++ b/apps/monitor-web/src/types/ToastType.ts
@@ -12,6 +12,8 @@ export interface Toast {
   id: string;
   /** 토스트에 표시할 메시지 */
   message: string;
+  /** 토스트에 표시할 부가 설명 */
+  description: string;
   /** 토스트 종류 */
   type: ToastType;
   /** 자동 제거까지의 시간 ms (default: 3000) */


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #34 
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 로그인 페이지에 Supabase 기반 로그인 기능을 추가했습니다.
- 로그인, 로그아웃, 사용자 정보 조회 로직을 추가했습니다.
- 버튼 컴포넌트의 로딩 스피너 위치가 화면 중앙에 표시되는 문제를 수정했습니다.
  - `relative` 속성이 누락되어 발생한 문제였습니다.
- 기존 토스트 컴포넌트에 `description` 옵션을 추가했습니다.

## 참고 사항

- 로그인 후 30분 유지 기능은 슬랙에 남겨둔 내용처럼 구현 방식에 대한 고민이 있어, 이번 작업에는 포함하지 않았습니다.
- 이후 작업으로 Protected Route 기능 추가 예정입니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거