### PR TITLE
feat: 보호 라우트 및 로그인 후 리다이렉트 처리 추가

### DIFF
--- a/apps/monitor-web/src/App.tsx
+++ b/apps/monitor-web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 import { Dashboard, Login, ErrorLog, ApiDetail, ApiEdit, ErrorDetail, NotFound } from "./pages";
 import { Nav, ToastContainer } from "./layouts";
+import { AuthRoute } from "./components";
 
 export default function App() {
   return (
@@ -10,11 +11,18 @@ export default function App() {
       <main className="flex-1 overflow-y-auto bg-[#F7F7F7] p-8">
         <Routes>
           <Route element={<Dashboard />} path="/" />
-          <Route element={<Login />} path="/login" />
-          <Route element={<ErrorLog />} path="/errors" />
-          <Route element={<ApiDetail />} path="/api/:apiId" />
-          <Route element={<ApiEdit />} path="/api/:apiId/edit" />
-          <Route element={<ErrorDetail />} path="/api/:apiId/errors/:errorId" />
+
+          <Route element={<AuthRoute requireAuth={false} />}>
+            <Route element={<Login />} path="/login" />
+          </Route>
+
+          <Route element={<AuthRoute requireAuth={true} />}>
+            <Route element={<ErrorLog />} path="/errors" />
+            <Route element={<ApiDetail />} path="/api/:apiId" />
+            <Route element={<ApiEdit />} path="/api/:apiId/edit" />
+            <Route element={<ErrorDetail />} path="/api/:apiId/errors/:errorId" />
+          </Route>
+
           <Route element={<NotFound />} path="*" />
         </Routes>
       </main>

--- a/apps/monitor-web/src/components/index.ts
+++ b/apps/monitor-web/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from "./common";
 export * from "./status";
+export * from "./routes";

--- a/apps/monitor-web/src/components/routes/AuthRoute.tsx
+++ b/apps/monitor-web/src/components/routes/AuthRoute.tsx
@@ -1,0 +1,28 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useUserQuery } from "@/queries/login/user.queries";
+import { LoadingSpinner } from "@/components";
+
+interface AuthRouteProps {
+  requireAuth: boolean;
+}
+
+export const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
+  const { data: user, isLoading } = useUserQuery();
+
+  if (isLoading) {
+    return (
+      <div className="h-full flex-center">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (requireAuth && !user) {
+    return <Navigate replace to="/login" />;
+  }
+  if (!requireAuth && user) {
+    return <Navigate replace to="/" />;
+  }
+
+  return <Outlet />;
+};

--- a/apps/monitor-web/src/components/routes/AuthRoute.tsx
+++ b/apps/monitor-web/src/components/routes/AuthRoute.tsx
@@ -2,11 +2,36 @@ import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useUserQuery } from "@/queries/login/user.queries";
 import { LoadingSpinner } from "@/components";
 
+/**
+ * 인증 여부에 따라 페이지 접근을 제어하고 리다이렉트를 처리하는 라우트 컴포넌트입니다.
+ *
+ * @remarks
+ * - 비로그인 사용자가 `requireAuth={true}` 라우트에 접근 시 `/login`으로 리다이렉트되며, 원래 접속하려던 경로를 `state.from`에 저장합니다.
+ * - 로그인한 사용자가 `requireAuth={false}` 라우트에 접근 시 메인(`/`)으로 리다이렉트됩니다.
+ *
+ * @author jikwon
+ */
+
 interface AuthRouteProps {
+  /**
+   * 인증 필요 여부
+   * `true`: 로그인한 사용자만 접근 가능
+   * `false`: 비로그인 사용자만 접근 가능
+   */
   requireAuth: boolean;
 }
 
-export const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
+/**
+ * @example
+ * ```tsx
+ * // 로그인한 사용자만 접근 가능한 라우트 설정
+ * <Route element={<AuthRoute requireAuth={true} />}>
+ *   <Route path="/dashboard" element={<Dashboard />} />
+ * </Route>
+ * ```
+ */
+
+const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
   const location = useLocation();
   const { data: user, isLoading } = useUserQuery();
 
@@ -28,3 +53,5 @@ export const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
 
   return <Outlet />;
 };
+
+export default AuthRoute;

--- a/apps/monitor-web/src/components/routes/AuthRoute.tsx
+++ b/apps/monitor-web/src/components/routes/AuthRoute.tsx
@@ -44,7 +44,9 @@ const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
   }
 
   if (requireAuth && !user) {
-    return <Navigate replace state={{ from: location.pathname }} to="/login" />;
+    return (
+      <Navigate replace state={{ from: `${location.pathname}${location.search}` }} to="/login" />
+    );
   }
 
   if (!requireAuth && user) {

--- a/apps/monitor-web/src/components/routes/AuthRoute.tsx
+++ b/apps/monitor-web/src/components/routes/AuthRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useUserQuery } from "@/queries/login/user.queries";
 import { LoadingSpinner } from "@/components";
 
@@ -7,6 +7,7 @@ interface AuthRouteProps {
 }
 
 export const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
+  const location = useLocation();
   const { data: user, isLoading } = useUserQuery();
 
   if (isLoading) {
@@ -18,8 +19,9 @@ export const AuthRoute = ({ requireAuth }: AuthRouteProps) => {
   }
 
   if (requireAuth && !user) {
-    return <Navigate replace to="/login" />;
+    return <Navigate replace state={{ from: location.pathname }} to="/login" />;
   }
+
   if (!requireAuth && user) {
     return <Navigate replace to="/" />;
   }

--- a/apps/monitor-web/src/components/routes/index.ts
+++ b/apps/monitor-web/src/components/routes/index.ts
@@ -1,0 +1,1 @@
+export * from "./AuthRoute";

--- a/apps/monitor-web/src/components/routes/index.ts
+++ b/apps/monitor-web/src/components/routes/index.ts
@@ -1,1 +1,1 @@
-export * from "./AuthRoute";
+export { default as AuthRoute } from "./AuthRoute";

--- a/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
+++ b/apps/monitor-web/src/pages/Login/hooks/useLoginForm.ts
@@ -4,18 +4,18 @@ import { LoginFormValues } from "../types";
 
 const useLoginForm = () => {
   const [values, setValues] = useState<LoginFormValues>({ username: "", password: "" });
-  const { mutateAsync: login, isPending } = useLoginMutation();
+  const { mutate: login, isPending } = useLoginMutation();
 
   const handleChange =
     (field: "username" | "password") => (event: ChangeEvent<HTMLInputElement>) => {
       setValues((prev) => ({ ...prev, [field]: event.target.value }));
     };
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (isPending) return;
 
-    await login(values);
+    login(values);
   };
 
   const isDisabled = isPending || !values.username.trim() || !values.password.trim();

--- a/apps/monitor-web/src/queries/login/login.queries.ts
+++ b/apps/monitor-web/src/queries/login/login.queries.ts
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
 import { useToast } from "@/hooks";
 import useAppMutation from "../base/useAppMutation";
@@ -17,13 +17,16 @@ const loginWithEmail = async ({ username, password }: LoginFormValues) => {
 
 export const useLoginMutation = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const { error: errorToast } = useToast();
+
+  const from = location.state?.from || "/";
 
   return useAppMutation(loginWithEmail, {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: authQueryKeys.user() });
-      navigate("/");
+      navigate(from, { replace: true });
     },
 
     onError: (error: Error) => {


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #38
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- 메인(대시보드)과 로그인 페이지를 제외한 모든 페이지를 보호 라우트로 구성했습니다.
- 비로그인 상태에서 보호 페이지 접근 시 로그인 페이지로 이동하도록 처리했습니다.
- 로그인 성공 후 이전 접근 페이지가 있으면 해당 페이지로, 없으면 메인(대시보드) 페이지로 이동하도록 수정했습니다.
  - 이전 경로 전달은 `Navigate`의 `state`와 `useLocation`을 사용했습니다.

## 참고 사항

- `AuthRoute.tsx` 컴포넌트 위치가 애매하다고 판단하여 `components/routes` 폴더를 생성하고 배럴 패턴으로 export하도록 구성했습니다.
- 이전 브랜치에서 이어서 작업한 브랜치라 파일 변경사항이 많습니다. 이전 PR 머지 후 리뷰해 주셔도 괜찮습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거