### PR TITLE
feat : vworld 헤더 구조 개선

### DIFF
--- a/apps/monitor-server/src/services/monitoring.processor.ts
+++ b/apps/monitor-server/src/services/monitoring.processor.ts
@@ -45,6 +45,8 @@ const buildRequestUrl = (rawUrl: string): string => {
  * - 기본적으로 `Accept: application/json` 헤더를 설정합니다.
  * - Kakao Local API(`dapi.kakao.com`) 요청인 경우
  *   `KAKAO_REST_API_KEY` 환경변수로 `Authorization` 헤더를 추가합니다.
+ * - Vworld(`api.vworld.kr`) 요청인 경우
+ *  게이트웨이/WAF 호환을 위해 `User-Agent`, `Referer` 헤더를 추가합니다.
  * 
  * @returns API 제공사별 인증 헤더가 반영된 요청 헤더 객체
  * 
@@ -60,6 +62,12 @@ const buildHeaders = (rawUrl: string): HeadersInit => {
     if (kakaoKey) {
       headers.Authorization = `KakaoAK ${kakaoKey}`;
     }
+  }
+
+  if (url.hostname === "api.vworld.kr") {
+    headers["User-Agent"] = 
+      "Mozilla/5.0 (Windows NT 10.0; Win64; 64) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/237.84.2.178 Safari/537.36";
+    headers.Referer = "https://www.finditem.kr";
   }
 
   return headers;

--- a/apps/monitor-server/src/services/monitoring.processor.ts
+++ b/apps/monitor-server/src/services/monitoring.processor.ts
@@ -66,7 +66,7 @@ const buildHeaders = (rawUrl: string): HeadersInit => {
 
   if (url.hostname === "api.vworld.kr") {
     headers["User-Agent"] = 
-      "Mozilla/5.0 (Windows NT 10.0; Win64; 64) AppleWebkit/537.36 (KHTML, like Gecko) Chrome/237.84.2.178 Safari/537.36";
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
     headers.Referer = "https://www.finditem.kr";
   }
 


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- issue #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- `monitoring.processor.ts`
 
   - vworld 요청시 추가적인 헤더 요소 작성

## 참고 사항

- 로컬상 테스트에서는 문제가 없었지만, 스케쥴러 진행시 vworld 요청만 `HTTP 502 Bad Gateway` 오류가 발생하는걸 인지하였습니다.
   정확한 해결방법을 찾지는 못했지만, 운영팀에서도 동일한 오류가 있던것으로 보아 동일한 구조로 개선하였습니다.

- 병합이후 스케쥴러 상 오류만 확인하면 될 것 같습니다.

## 체크리스트

- [x] 기능이 정상 동작하는지 확인
- [x] 불필요한 코드/주석 제거
