### PR TITLE
chore: 깃허브 액션 개인 토큰을 GitHub App 토큰으로 교체

### DIFF
--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -10,9 +10,16 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Assign issue to author
         uses: pozil/auto-assign-issue@v2
         with:
-          repo-token: ${{ secrets.YML_GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           assignees: ${{ github.event.issue.user.login }}
           allowSelfAssign: true

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,7 +11,14 @@ jobs:
   addReviewers:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: kentaro-m/auto-assign-action@v2.0.1
         with:
-          repo-token: ${{ secrets.YML_GITHUB_TOKEN }}
+          repo-token: ${{ steps.app-token.outputs.token }}
           configuration-path: .github/auto_assign.yml

--- a/.github/workflows/build-design-tokens.yml
+++ b/.github/workflows/build-design-tokens.yml
@@ -19,10 +19,17 @@ jobs:
       contents: write
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.YML_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/develop-to-main-pr.yml
+++ b/.github/workflows/develop-to-main-pr.yml
@@ -13,6 +13,13 @@ jobs:
   create-or-update-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -20,7 +27,7 @@ jobs:
 
       - name: Create or Update Pull Request
         env:
-          GH_TOKEN: ${{ secrets.YML_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git fetch origin main
           


### PR DESCRIPTION
# Pull Request

## 관련 이슈

- close #이슈번호
  <!-- 또는 issue #이슈번호 -->

## 작업 내용

- GitHub Actions에서 사용하던 개인 토큰을 제거했습니다.
- 자동 PR 생성에 사용할 `finditem-bot` GitHub App을 추가했습니다.
- 자동화로 생성되는 PR 작성자가 개인 계정이 아닌 `finditem-bot[bot]`으로 표시되도록 구성했습니다.

## 참고 사항

- 머지 후 깃허브 액션이 정상 동작 하는지 테스트가 필요합니다.

## 체크리스트

- [ ] 기능이 정상 동작하는지 확인
- [ ] 불필요한 코드/주석 제거
